### PR TITLE
Fix CSS for menu paragraphs

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -114,7 +114,7 @@ th, td {
   margin: 20px;
 }
 
-text-center {
+.text-center {
   color: white;
   text-align: center;
   }


### PR DESCRIPTION
The class selector on line 117 for menu paragraphs called text-center was missing a period in front of it causing the ruleset not to be enacted